### PR TITLE
Make azurerm/azuread version constraints less restrictive (fixes #9)

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -3,12 +3,12 @@ terraform {
 
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = "3.7.0"
+      source  = "hashicorp/azurerm"
+      version = ">=3.7.0"
     }
     azuread = {
-      source = "hashicorp/azuread"
-      version = "2.22.0"
+      source  = "hashicorp/azuread"
+      version = ">=2.22.0"
     }
     castai = {
       source  = "castai/castai"


### PR DESCRIPTION
This PR serves to make the azurerm/azuread version constraints less restrictive, to allow people depending on this module to upgrade past azurerm 3.7.0 and azuread 2.22.0.

There are no breaking changes for the resources used in this module from those providers, up to the latest versions of both.