### PR TITLE
feat(aks): Allow users whom have Kubernetes cluster resources such as VNets in a Resource Group outside of the AKS Cluster Resource Group

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -52,10 +52,11 @@ resource "azurerm_role_definition" "castai" {
     not_actions = []
   }
 
-  assignable_scopes = [
+  assignable_scopes = distinct(compact([
     "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}",
-    "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}"
-  ]
+    "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}",
+    var.network_resource_group != "" ? "/subscriptions/${var.subscription_id}/resourceGroups/${var.network_resource_group}" : null
+  ]))
 }
 
 

--- a/iam.tf
+++ b/iam.tf
@@ -74,6 +74,13 @@ resource "azurerm_role_assignment" "castai_node_resource_group" {
   scope = "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}"
 }
 
+resource "azurerm_role_assignment" "castai_additional_resource_groups" {
+  for_each           = toset(var.additional_resource_groups)
+  principal_id       = azuread_service_principal.castai.id
+  role_definition_id = azurerm_role_definition.castai.role_definition_resource_id
+  scope              = each.key
+}
+
 // Azure AD
 
 data "azuread_client_config" "current" {}

--- a/iam.tf
+++ b/iam.tf
@@ -52,11 +52,11 @@ resource "azurerm_role_definition" "castai" {
     not_actions = []
   }
 
-  assignable_scopes = distinct(compact([
+  assignable_scopes = flatten(distinct(compact([
     "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}",
     "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}",
-    var.network_resource_group != "" ? "/subscriptions/${var.subscription_id}/resourceGroups/${var.network_resource_group}" : null
-  ]))
+    var.additional_resource_groups
+  ])))
 }
 
 

--- a/iam.tf
+++ b/iam.tf
@@ -52,7 +52,7 @@ resource "azurerm_role_definition" "castai" {
     not_actions = []
   }
 
-  assignable_scopes = flatten(distinct(compact([
+  assignable_scopes = distinct(compact(flatten([
     "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group}",
     "/subscriptions/${var.subscription_id}/resourceGroups/${var.node_resource_group}",
     var.additional_resource_groups

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,11 @@ variable "resource_group" {
   type = string
 }
 
+variable "network_resource_group" {
+  type    = string
+  default = ""
+}
+
 variable "node_resource_group" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "resource_group" {
 }
 
 variable "additional_resource_groups" {
-  type    = array(string)
+  type    = list(string)
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,9 +35,9 @@ variable "resource_group" {
   type = string
 }
 
-variable "network_resource_group" {
-  type    = string
-  default = ""
+variable "additional_resource_groups" {
+  type    = array(string)
+  default = []
 }
 
 variable "node_resource_group" {


### PR DESCRIPTION
Use case for this is that our AKS cluster uses a networking VNet outside of the resource group of the cluster itself.