### PR TITLE
Add artificial resource in order to wait for cluster to be in ready s…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -226,7 +226,7 @@ resource "null_resource" "wait_for_cluster" {
       API_KEY = var.castai_api_token
     }
     command = <<-EOT
-        RETRY_COUNT=20
+        RETRY_COUNT=30
         POOLING_INTERVAL=30
 
         for i in $(seq 1 $RETRY_COUNT); do
@@ -234,7 +234,7 @@ resource "null_resource" "wait_for_cluster" {
             curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_aks_cluster.castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
         done
 
-        echo "Cluster is not ready after 10 minutes"
+        echo "Cluster is not ready after 15 minutes"
         exit 1
     EOT
 

--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,32 @@ resource "helm_release" "castai_cluster_controller" {
   }
 }
 
+resource "null_resource" "wait_for_cluster" {
+  count = var.wait_for_cluster_ready ? 1 : 0
+  depends_on = [helm_release.castai_cluster_controller, helm_release.castai_agent]
+
+  provisioner "local-exec" {
+    quiet = true
+    environment = {
+      API_KEY = var.castai_api_token
+    }
+    command = <<-EOT
+        RETRY_COUNT=20
+        POOLING_INTERVAL=30
+
+        for i in $(seq 1 $RETRY_COUNT); do
+            sleep $POOLING_INTERVAL
+            curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_gke_cluster.castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
+        done
+
+        echo "Cluster is not ready after 10 minutes"
+        exit 1
+    EOT
+
+    interpreter = ["bash", "-c"]
+  }
+}
+
 resource "helm_release" "castai_spot_handler" {
   name             = "castai-spot-handler"
   repository       = "https://castai.github.io/helm-charts"

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ resource "null_resource" "wait_for_cluster" {
 
         for i in $(seq 1 $RETRY_COUNT); do
             sleep $POOLING_INTERVAL
-            curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_gke_cluster.castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
+            curl -s ${var.api_url}/v1/kubernetes/external-clusters/${castai_aks_cluster.castai_cluster.id} -H "x-api-key: $API_KEY" | grep '"status"\s*:\s*"ready"' && exit 0
         done
 
         echo "Cluster is not ready after 10 minutes"

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "api_url" {
   default     = "https://api.cast.ai"
 }
 
+variable "castai_api_token" {
+  type = string
+  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  sensitive = true
+}
+
 variable "aks_cluster_name" {
   type        = string
   description = "Name of the cluster to be connected to CAST AI."
@@ -135,4 +141,10 @@ variable "kvisor_version" {
   description = "Version of kvisor chart. If not provided, latest version will be used."
   type        = string
   default     = null
+}
+
+variable "wait_for_cluster_ready" {
+  type        = bool
+  description = "Wait for cluster to be ready before finishing the module execution"
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,9 @@ variable "api_url" {
 
 variable "castai_api_token" {
   type = string
-  description = "CAST AI API token created in console.cast.ai API Access keys section."
+  description = "Optional CAST AI API token created in console.cast.ai API Access keys section. Used only when `wait_for_cluster_ready` is set to true"
   sensitive = true
+  default = ""
 }
 
 variable "aks_cluster_name" {
@@ -145,6 +146,6 @@ variable "kvisor_version" {
 
 variable "wait_for_cluster_ready" {
   type        = bool
-  description = "Wait for cluster to be ready before finishing the module execution"
-  default     = true
+  description = "Wait for cluster to be ready before finishing the module execution, this option requires `castai_api_token` to be set"
+  default     = false
 }


### PR DESCRIPTION
…tate

This commit introduces a change that will block module completion up until created cluster is in the Ready state.

Natural candidate for cluster ready state is castai_xxx_cluster resource creation step. Hoverer as cluster resource needs to finish its creation in order to run helm charts that actually deploys components that makes cluster to transit to ready state we need to introduce custom resource that will depend on helm charts resources that will pool ready state.

To accomplish this null_resource was introduced that pools created cluster status until it is in ready state.