### PR TITLE
Renamed deprecated application_id to client_id

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -95,7 +95,7 @@ resource "azuread_application_password" "castai" {
 }
 
 resource "azuread_service_principal" "castai" {
-  application_id               = azuread_application.castai.application_id
+  client_id                    = azuread_application.castai.client_id
   app_role_assignment_required = false
   owners                       = [data.azuread_client_config.current.object_id]
 }


### PR DESCRIPTION
azuread_service_principal attribute was renamed from application_id to client_id (https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal)

This fixes the warning: The attribute "application_id" is deprecated. Refer to the provider documentation for details.