### PR TITLE
Add node template rebalacing config for minimum nodes.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,11 +46,12 @@ resource "castai_node_template" "this" {
 
   cluster_id = castai_aks_cluster.castai_cluster.id
 
-  name             = try(each.value.name, each.key)
-  is_default       = try(each.value.is_default, false)
-  is_enabled       = try(each.value.is_enabled, null)
-  configuration_id = can(each.value.configuration_id) ? length(regexall(local.configuration_id_regex_pattern, each.value.configuration_id)) > 0 ? each.value.configuration_id : castai_node_configuration.this[each.value.configuration_id].id : null
-  should_taint     = try(each.value.should_taint, true)
+  name                         = try(each.value.name, each.key)
+  is_default                   = try(each.value.is_default, false)
+  is_enabled                   = try(each.value.is_enabled, null)
+  configuration_id             = can(each.value.configuration_id) ? length(regexall(local.configuration_id_regex_pattern, each.value.configuration_id)) > 0 ? each.value.configuration_id : castai_node_configuration.this[each.value.configuration_id].id : null
+  should_taint                 = try(each.value.should_taint, true)
+  rebalancing_config_min_nodes = try(each.value.rebalancing_config_min_nodes, 0)
 
   custom_labels = try(each.value.custom_labels, {})
 


### PR DESCRIPTION
This allows users to specify the node template's rebalancing config minimum nodes setting so that a rebalancer schedule does not reduce a template down to a single node.