### PR TITLE
fix: filter out null values from constraints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,8 @@ resource "castai_node_template" "this" {
   }
 
   dynamic "constraints" {
-    for_each = flatten([lookup(each.value, "constraints", [])])
+    for_each = [for constraints in flatten([lookup(each.value, "constraints", [])]) : constraints if constraints != null]
+
     content {
       compute_optimized                           = try(constraints.value.compute_optimized, null)
       storage_optimized                           = try(constraints.value.storage_optimized, null)
@@ -103,7 +104,7 @@ resource "castai_node_template" "this" {
       azs                                         = try(constraints.value.azs, null)
 
       dynamic "instance_families" {
-        for_each = flatten([lookup(constraints.value, "instance_families", [])])
+        for_each = [for instance_families in flatten([lookup(constraints.value, "instance_families", [])]) : instance_families if instance_families != null]
 
         content {
           include = try(instance_families.value.include, [])
@@ -112,7 +113,7 @@ resource "castai_node_template" "this" {
       }
 
       dynamic "custom_priority" {
-        for_each = flatten([lookup(constraints.value, "custom_priority", [])])
+        for_each = [for custom_priority in flatten([lookup(constraints.value, "custom_priority", [])]) : custom_priority if custom_priority != null]
 
         content {
           instance_families = try(custom_priority.value.instance_families, [])


### PR DESCRIPTION
Terraform, counts `null` values as a value while looking up variables. As a result of this when we set `foo = null` following example code generates a config block instead of skipping it

```hcl
dynamic "foo" {
    for_each = flatten([lookup(each.value, "foo", [])])

    ...
}
```

diff:

```hcl
+ foo {}
```

This PR filters null values from `constraints`  keys to avoid empty config blocks