### PR TITLE
KUBE-856: Support http proxy config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   configuration_id_regex_pattern = "[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}"
+  has_http_proxy = length(var.no_proxy) > 0 || (var.http_proxy != null && var.http_proxy != "") || (var.https_proxy != null && var.https_proxy != "")
 }
 
 resource "castai_aks_cluster" "castai_cluster" {
@@ -13,6 +14,16 @@ resource "castai_aks_cluster" "castai_cluster" {
 
   node_resource_group        = var.node_resource_group
   delete_nodes_on_disconnect = var.delete_nodes_on_disconnect
+  
+  dynamic "http_proxy_config" {
+    for_each = local.has_http_proxy ? [true] : []
+
+    content {
+      http_proxy = try(var.http_proxy, null)
+      https_proxy = try(var.https_proxy, null)
+      no_proxy = try(var.no_proxy, [])
+    }
+  }
 
   # CastAI needs cloud permission to do some clean up
   # when disconnecting the cluster.

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,24 @@ variable "tenant_id" {
   type = string
 }
 
+variable "http_proxy" {
+  type = string
+  description = "Address to use for proxying http requests from CAST AI components running directly on nodes."
+  default = null
+}
+
+variable "https_proxy" {
+  type = string
+  description = "Address to use for proxying https requests from CAST AI components running directly on nodes."
+  default = null
+}
+
+variable "no_proxy" {
+  type = list(string)
+  description = "List of addresses to skip proxying requests from CAST AI components running directly on nodes. Used with http_proxy and https_proxy."
+  default = []
+}
+
 variable "castai_components_labels" {
   type        = map(any)
   description = "Optional additional Kubernetes labels for CAST AI pods"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = "~> 7.33"
+      version = "~> 7.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = "~> 7.32"
+      version = "~> 7.33"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Depends on terraform provider being released first - see https://github.com/castai/terraform-provider-castai/pull/448 .