### PR TITLE
CFR-722 -- Add ignore lifecycle for owners

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -88,14 +88,24 @@ data "azuread_client_config" "current" {}
 resource "azuread_application" "castai" {
   display_name = local.app_name
   owners       = [data.azuread_client_config.current.object_id]
+  lifecycle {
+    ignore_changes = [
+      owners,
+    ]
+  }
 }
 
 resource "azuread_application_password" "castai" {
-  application_id         = azuread_application.castai.id
+  application_id = azuread_application.castai.id
 }
 
 resource "azuread_service_principal" "castai" {
   client_id                    = azuread_application.castai.client_id
   app_role_assignment_required = false
   owners                       = [data.azuread_client_config.current.object_id]
+  lifecycle {
+    ignore_changes = [
+      owners,
+    ]
+  }
 }


### PR DESCRIPTION
Currently the owners field in azuread_application and azuread_service_principal is populated based on the user or role executing terraform apply (via the azuread_client_config data object). This causes unwanted drifts whenever a different user or role applies the Terraform code (e.g. other developer running Terraform apply locally). 

By adding the `lifecycle { ignore_changes = [owners] }` block we will prevent Terraform from attempting unnecessary updates to this field.

As a long term solution, we should probably rewrite the module to allow users to specify the owners field, instead of setting it inside the module to avoid such issues, but that would be a breaking change, that requires a major version update, so for now I think this workaround should be enough. 