### PR TITLE
Fix strict vs non-strict default value - main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "castai_node_template" "this" {
   custom_labels = try(each.value.custom_labels, {})
 
   dynamic "custom_taints" {
-    for_each = flatten([lookup(each.value, "custom_taints", [])])
+    for_each = flatten([try(each.value.custom_taints, [])])
 
     content {
       key    = try(custom_taints.value.key, null)
@@ -136,7 +136,7 @@ resource "castai_node_template" "this" {
   }
 
   dynamic "constraints" {
-    for_each = [for constraints in flatten([lookup(each.value, "constraints", [])]) : constraints if constraints != null]
+    for_each = [for constraints in flatten([try(each.value.constraints, [])]) : constraints if constraints != null]
 
     content {
       compute_optimized                             = try(constraints.value.compute_optimized, null)
@@ -167,7 +167,7 @@ resource "castai_node_template" "this" {
       is_gpu_only                                   = try(constraints.value.is_gpu_only, false)
 
       dynamic "instance_families" {
-        for_each = [for instance_families in flatten([lookup(constraints.value, "instance_families", [])]) : instance_families if instance_families != null]
+        for_each = [for instance_families in flatten([try(constraints.value.instance_families, [])]) : instance_families if instance_families != null]
 
         content {
           include = try(instance_families.value.include, [])
@@ -176,7 +176,7 @@ resource "castai_node_template" "this" {
       }
 
       dynamic "custom_priority" {
-        for_each = [for custom_priority in flatten([lookup(constraints.value, "custom_priority", [])]) : custom_priority if custom_priority != null]
+        for_each = [for custom_priority in flatten([try(constraints.value.custom_priority, [])]) : custom_priority if custom_priority != null]
 
         content {
           instance_families = try(custom_priority.value.instance_families, [])
@@ -186,7 +186,7 @@ resource "castai_node_template" "this" {
       }
 
       dynamic "gpu" {
-        for_each = [for gpu in flatten([lookup(constraints.value, "gpu", [])]) : gpu if gpu != null]
+        for_each = [for gpu in flatten([try(constraints.value.gpu, [])]) : gpu if gpu != null]
 
         content {
           manufacturers = try(gpu.value.manufacturers, [])
@@ -198,7 +198,7 @@ resource "castai_node_template" "this" {
       }
 
       dynamic "resource_limits" {
-        for_each = [for resource_limits in flatten([lookup(constraints.value, "resource_limits", [])]) : resource_limits if resource_limits != null]
+        for_each = [for resource_limits in flatten([try(constraints.value.resource_limits, [])]) : resource_limits if resource_limits != null]
 
         content {
           cpu_limit_enabled   = try(resource_limits.value.cpu_limit_enabled, false)


### PR DESCRIPTION
I believe the errors below are due to using lookup() which doesn't expect a different datatype. 
A quick fix would be to use try() instead which could work with the currently given defaults such as `[]`. A more proper fix might be desired on the long run though





example data being passed:

```
# Custom implementation passing the following values to cast.ai's castai/aks/castai=8.0.3
      + PlatformApi        = {
          + configuration_id = "<<redacted>>"
          + constraints      = {
              + fallback_restore_rate_seconds                 = "1800"
              + on_demand                                     = "false"
              + spot                                          = "true"
              + spot_interruption_predictions_type            = "interruption-predictions"
              + spot_reliability_enabled                      = "true"
              + spot_reliability_price_increase_limit_percent = "20"
              + use_spot_fallbacks                            = "true"
            }
          + custom_labels    = {
              + "platform.api" = "true"
            }
          + should_taint     = false
        }
```

```
# the node template outputted from cast.ai's castai/aks/castai=8.0.3
{
      + cluster_id                                    = "<<redacted>>"
      + configuration_id                              = "<<redacted>>"
      + constraints                                   = [
          + {
              + architecture_priority                         = []
              + architectures                                 = [
                  + "amd64",
                ]
              + azs                                           = []
              + bare_metal                                    = "unspecified"
              + burstable_instances                           = ""
              + compute_optimized                             = false
              + compute_optimized_state                       = ""
              + cpu_manufacturers                             = []
              + custom_priority                               = []
              + customer_specific                             = ""
              + dedicated_node_affinity                       = []
              + enable_spot_diversity                         = false
              + fallback_restore_rate_seconds                 = 1800
              + gpu                                           = []
              + instance_families                             = []
              + is_gpu_only                                   = false
              + max_cpu                                       = 0
              + max_memory                                    = 0
              + min_cpu                                       = 0
              + min_memory                                    = 0
              + on_demand                                     = false
              + os                                            = [
                  + "linux",
                ]
              + resource_limits                               = [
                  + {
                      + cpu_limit_enabled   = false
                      + cpu_limit_max_cores = 0
                    },
                ]
              + spot                                          = true
              + spot_diversity_price_increase_limit_percent   = null
              + spot_interruption_predictions_enabled         = false
              + spot_interruption_predictions_type            = "interruption-predictions"
              + spot_reliability_enabled                      = true
              + spot_reliability_price_increase_limit_percent = 20
              + storage_optimized                             = false
              + storage_optimized_state                       = ""
              + use_spot_fallbacks                            = true
            },
        ]
      + custom_instances_enabled                      = false
      + custom_instances_with_extended_memory_enabled = false
      + custom_labels                                 = {
          + "platform.api" = "true"
        }
      + custom_taints                                 = []
      + gpu                                           = [
          + {
              + default_shared_clients_per_gpu = 0
              + enable_time_sharing            = false
              + sharing_configuration          = []
            },
        ]
      + id                                            = "PlatformApi"
      + is_default                                    = false
      + is_enabled                                    = true
      + name                                          = "PlatformApi"
      + rebalancing_config_min_nodes                  = 0
      + should_taint                                  = false
      + timeouts                                      = null
    }
```




the following errors are generated:

```
│ Error: Invalid function argument
│ 
│   on .terraform/modules/mod_castai.connected/main.tf line 170, in resource "castai_node_template" "this":
│  170:         for_each = [for instance_families in flatten([lookup(constraints.value, "instance_families", [])]) : instance_families if instance_families != null]
│ 
│ Invalid value for "default" parameter: the default value must have the same
│ type as the map elements.
╵
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/mod_castai.connected/main.tf line 179, in resource "castai_node_template" "this":
│  179:         for_each = [for custom_priority in flatten([lookup(constraints.value, "custom_priority", [])]) : custom_priority if custom_priority != null]
│ 
│ Invalid value for "default" parameter: the default value must have the same
│ type as the map elements.
╵
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/mod_castai.connected/main.tf line 189, in resource "castai_node_template" "this":
│  189:         for_each = [for gpu in flatten([lookup(constraints.value, "gpu", [])]) : gpu if gpu != null]
│ 
│ Invalid value for "default" parameter: the default value must have the same
│ type as the map elements.
╵
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/mod_castai.connected/main.tf line 201, in resource "castai_node_template" "this":
│  201:         for_each = [for resource_limits in flatten([lookup(constraints.value, "resource_limits", [])]) : resource_limits if resource_limits != null]
│ 
│ Invalid value for "default" parameter: the default value must have the same
│ type as the map elements.
╵
```


