### PR TITLE
chore!: move to helm provider v3

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,40 @@
+locals {
+  # Common conditional non-sensitive values that we pass to helm_releases.
+  # Set up as lists so they can be concatenated.
+  set_apiurl = var.api_url != "" ? [{
+    name  = "castai.apiURL"
+    value = var.api_url
+  }] : []
+  set_cluster_id = [{
+    name  = "castai.clusterID"
+    value = castai_aks_cluster.castai_cluster.id
+  }]
+  set_organization_id = var.organization_id != "" ? [{
+    name  = "castai.organizationID"
+    value = var.organization_id
+  }] : []
+  set_grpc_url = var.grpc_url != "" ? [{
+    name  = "castai.grpcURL"
+    value = var.grpc_url
+  }] : []
+  set_kvisor_grpc_addr = var.kvisor_grpc_addr != "" ? [{
+    name  = "castai.grpcAddr"
+    value = var.kvisor_grpc_addr
+  }] : []
+  set_pod_labels = [for k, v in var.castai_components_labels : {
+    name  = "podLabels.${k}"
+    value = v
+  }]
+  set_components_sets = [for k, v in var.castai_components_sets : {
+    name  = k
+    value = v
+  }]
+
+
+  # Common conditional SENSITIVE values that we pass to helm_releases.
+  # Set up as lists so they can be concatenated.
+  set_sensitive_apikey = [{
+    name  = "castai.apiKey"
+    value = castai_aks_cluster.castai_cluster.cluster_token
+  }]
+}

--- a/main.tf
+++ b/main.tf
@@ -243,48 +243,37 @@ resource "helm_release" "castai_agent" {
   version = var.agent_version
   values  = var.agent_values
 
-  set {
-    name  = "replicaCount"
-    value = "2"
-  }
-  set {
-    name  = "provider"
-    value = "aks"
-  }
-
-  set {
-    name  = "createNamespace"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
+  set = concat(
+    [
+      {
+        name  = "replicaCount"
+        value = "2"
+        }, {
+        name  = "provider"
+        value = "aks"
+        }, {
+        name  = "createNamespace"
+        value = "false"
+      }
+    ],
+    // castai-agent chart requires "apiURL" on the top level, NOT under "castai.apiURL"
+    var.api_url != "" ? [{
       name  = "apiURL"
       value = var.api_url
-    }
-  }
+    }] : [],
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  set_sensitive {
-    name  = "apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
+  set_sensitive = concat(
+    [
+      // castai-agent chart requires "apiKey" on the top level, NOT under "castai.apiKey"
+      {
+        name  = "apiKey"
+        value = castai_aks_cluster.castai_cluster.cluster_token
+      }
+    ],
+  )
 }
 
 resource "helm_release" "castai_cluster_controller" {
@@ -301,44 +290,20 @@ resource "helm_release" "castai_cluster_controller" {
   version = var.cluster_controller_version
   values  = var.cluster_controller_values
 
-  set {
-    name  = "aks.enabled"
-    value = "true"
-  }
+  set = concat(
+    [
+      {
+        name  = "aks.enabled"
+        value = "true"
+      },
+    ],
+    local.set_cluster_id,
+    local.set_apiurl,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
-
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent]
 
@@ -361,44 +326,20 @@ resource "helm_release" "castai_cluster_controller_self_managed" {
   version = var.cluster_controller_version
   values  = var.cluster_controller_values
 
-  set {
-    name  = "aks.enabled"
-    value = "true"
-  }
+  set = concat(
+    [
+      {
+        name  = "aks.enabled"
+        value = "true"
+      },
+    ],
+    local.set_cluster_id,
+    local.set_apiurl,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
-
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent]
 }
@@ -442,31 +383,20 @@ resource "helm_release" "castai_evictor" {
   version = var.evictor_version
   values  = var.evictor_values
 
-  set {
-    name  = "replicaCount"
-    value = "0"
-  }
-
-  set {
-    name  = "castai-evictor-ext.enabled"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set = concat(
+    [
+      {
+        name  = "replicaCount"
+        value = "0"
+      },
+      {
+        name  = "castai-evictor-ext.enabled"
+        value = "false"
+      },
+    ],
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
   depends_on = [helm_release.castai_agent]
 
@@ -489,40 +419,26 @@ resource "helm_release" "castai_evictor_self_managed" {
   version = var.evictor_version
   values  = var.evictor_values
 
-  set {
-    name  = "castai-evictor-ext.enabled"
-    value = "false"
-  }
-
-  set {
-    name  = "managedByCASTAI"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = try(var.autoscaler_settings.node_downscaler.evictor.enabled, null) == false ? [0] : []
-
-    content {
-      name  = "replicaCount"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set = concat(
+    [
+      {
+        name  = "castai-evictor-ext.enabled"
+        value = "false"
+      },
+      {
+        name  = "managedByCASTAI"
+        value = "false"
+      },
+    ],
+    try(var.autoscaler_settings.node_downscaler.evictor.enabled, null) == false ? [
+      {
+        name  = "replicaCount"
+        value = "0"
+      }
+    ] : [],
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
   depends_on = [helm_release.castai_agent]
 }
@@ -556,52 +472,21 @@ resource "helm_release" "castai_pod_pinner" {
   version = var.pod_pinner_version
   values  = var.pod_pinner_values
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
+  set = concat(
+    [
+      {
+        name  = "replicaCount"
+        value = "0"
+      }
+    ],
+    local.set_cluster_id,
+    local.set_apiurl,
+    local.set_grpc_url,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
-
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-  dynamic "set" {
-    for_each = var.grpc_url != "" ? [var.grpc_url] : []
-    content {
-      name  = "castai.grpcURL"
-      value = var.grpc_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "replicaCount"
-    value = "0"
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent]
 
@@ -624,61 +509,27 @@ resource "helm_release" "castai_pod_pinner_self_managed" {
   version = var.pod_pinner_version
   values  = var.pod_pinner_values
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
+  set = concat(
+    [
+      {
+        name  = "managedByCASTAI"
+        value = "false"
+      }
+    ],
+    local.set_cluster_id,
+    local.set_apiurl,
+    local.set_grpc_url,
+    local.set_pod_labels,
+    local.set_components_sets,
+    try(var.autoscaler_settings.unschedulable_pods.pod_pinner.enabled, null) == false ? [
+      {
+        name  = "replicaCount"
+        value = "0"
+      }
+    ] : [],
+  )
 
-  set {
-    name  = "managedByCASTAI"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = try(var.autoscaler_settings.unschedulable_pods.pod_pinner.enabled, null) == false ? [0] : []
-
-    content {
-      name  = "replicaCount"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
-
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-  dynamic "set" {
-    for_each = var.grpc_url != "" ? [var.grpc_url] : []
-    content {
-      name  = "castai.grpcURL"
-      value = var.grpc_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent]
 }
@@ -695,44 +546,22 @@ resource "helm_release" "castai_spot_handler" {
   version = var.spot_handler_version
   values  = var.spot_handler_values
 
-  set {
-    name  = "castai.provider"
-    value = "azure"
-  }
-
-  set {
-    name  = "createNamespace"
-    value = "false"
-  }
-
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
+  set = concat(
+    [
+      {
+        name  = "castai.provider"
+        value = "azure"
+      },
+      {
+        name  = "createNamespace"
+        value = "false"
+      }
+    ],
+    local.set_apiurl,
+    local.set_cluster_id,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
   depends_on = [helm_release.castai_agent]
 }
@@ -754,41 +583,23 @@ resource "helm_release" "castai_kvisor" {
     ignore_changes = [version]
   }
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
+  set = concat(
+    [
+      {
+        name  = "controller.extraArgs.kube-bench-cloud-provider"
+        value = "aks"
+      },
+    ],
+    local.set_cluster_id,
+    local.set_kvisor_grpc_addr,
+    local.set_components_sets,
+    [for k, v in var.kvisor_controller_extra_args : {
+      name  = "controller.extraArgs.${k}"
+      value = v
+    }]
+  )
 
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-  set {
-    name  = "castai.grpcAddr"
-    value = var.kvisor_grpc_addr
-  }
-
-  dynamic "set" {
-    for_each = var.kvisor_controller_extra_args
-    content {
-      name  = "controller.extraArgs.${set.key}"
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "controller.extraArgs.kube-bench-cloud-provider"
-    value = "aks"
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set_sensitive = local.set_sensitive_apikey
 }
 
 resource "helm_release" "castai_kvisor_self_managed" {
@@ -804,41 +615,23 @@ resource "helm_release" "castai_kvisor_self_managed" {
   version = var.kvisor_version
   values  = var.kvisor_values
 
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
+  set = concat(
+    [
+      {
+        name  = "controller.extraArgs.kube-bench-cloud-provider"
+        value = "aks"
+      },
+    ],
+    local.set_cluster_id,
+    local.set_kvisor_grpc_addr,
+    local.set_components_sets,
+    [for k, v in var.kvisor_controller_extra_args : {
+      name  = "controller.extraArgs.${k}"
+      value = v
+    }]
+  )
 
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-  set {
-    name  = "castai.grpcAddr"
-    value = var.kvisor_grpc_addr
-  }
-
-  dynamic "set" {
-    for_each = var.kvisor_controller_extra_args
-    content {
-      name  = "controller.extraArgs.${set.key}"
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "controller.extraArgs.kube-bench-cloud-provider"
-    value = "aks"
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set_sensitive = local.set_sensitive_apikey
 }
 
 #---------------------------------------------------#
@@ -858,23 +651,19 @@ resource "helm_release" "castai_workload_autoscaler" {
   version = var.workload_autoscaler_version
   values  = var.workload_autoscaler_values
 
-  set {
-    name  = "castai.apiKeySecretRef"
-    value = "castai-cluster-controller"
-  }
-
-  set {
-    name  = "castai.configMapRef"
-    value = "castai-cluster-controller"
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set = concat(
+    [
+      {
+        name  = "castai.apiKeySecretRef"
+        value = "castai-cluster-controller"
+      },
+      {
+        name  = "castai.configMapRef"
+        value = "castai-cluster-controller"
+      },
+    ],
+    local.set_components_sets,
+  )
 
   depends_on = [helm_release.castai_agent, helm_release.castai_cluster_controller]
 
@@ -897,15 +686,19 @@ resource "helm_release" "castai_workload_autoscaler_self_managed" {
   version = var.workload_autoscaler_version
   values  = var.workload_autoscaler_values
 
-  set {
-    name  = "castai.apiKeySecretRef"
-    value = "castai-cluster-controller"
-  }
-
-  set {
-    name  = "castai.configMapRef"
-    value = "castai-cluster-controller"
-  }
+  set = concat(
+    [
+      {
+        name  = "castai.apiKeySecretRef"
+        value = "castai-cluster-controller"
+      },
+      {
+        name  = "castai.configMapRef"
+        value = "castai-cluster-controller"
+      },
+    ],
+    local.set_components_sets,
+  )
 
   depends_on = [helm_release.castai_agent, helm_release.castai_cluster_controller]
 }
@@ -927,48 +720,15 @@ resource "helm_release" "castai_pod_mutator" {
   version = var.pod_mutator_version
   values  = var.pod_mutator_values
 
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
+  set = concat(
+    local.set_cluster_id,
+    local.set_organization_id,
+    local.set_apiurl,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-
-  dynamic "set" {
-    for_each = var.organization_id != "" ? [var.organization_id] : []
-    content {
-      name  = "castai.organizationID"
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent, helm_release.castai_cluster_controller]
 
@@ -991,47 +751,15 @@ resource "helm_release" "castai_pod_mutator_self_managed" {
   version = var.pod_mutator_version
   values  = var.pod_mutator_values
 
-  dynamic "set" {
-    for_each = var.api_url != "" ? [var.api_url] : []
-    content {
-      name  = "castai.apiURL"
-      value = var.api_url
-    }
-  }
+  set = concat(
+    local.set_cluster_id,
+    local.set_organization_id,
+    local.set_apiurl,
+    local.set_pod_labels,
+    local.set_components_sets,
+  )
 
-  set_sensitive {
-    name  = "castai.apiKey"
-    value = castai_aks_cluster.castai_cluster.cluster_token
-  }
-
-  dynamic "set" {
-    for_each = var.organization_id != "" ? [var.organization_id] : []
-    content {
-      name  = "castai.organizationID"
-      value = set.value
-    }
-  }
-
-  set {
-    name  = "castai.clusterID"
-    value = castai_aks_cluster.castai_cluster.id
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_labels
-    content {
-      name  = "podLabels.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.castai_components_sets
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set_sensitive = local.set_sensitive_apikey
 
   depends_on = [helm_release.castai_agent, helm_release.castai_cluster_controller]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0.0"
+      version = ">= 3.0.0"
     }
 
     null = {


### PR DESCRIPTION
BREAKING CHANGE: adapting the Helm resources to the 3.x version of Helm provider. No longer compatible with 2.x versions of the Helm provider.

The [v3 release of the Helm provider](https://github.com/hashicorp/terraform-provider-helm/releases/tag/v3.0.0) came with a set of breaking changes around certain attributes becoming nested objects instead of individual blocks (e.g. `set` and `set_sensitive`). This PR adapts the module to these changes following the [migration guide](https://github.com/hashicorp/terraform-provider-helm/blob/v3.0.0/docs/guides/v3-upgrade-guide.md) of the helm provider. 

## Proof of Work

To make sure that the new version will generte the same underlying Helm releases, I've made the following changes to get the manifests and compare them before and after this change:

- Removed all resources not related to the Helm releases (`castai_aks_cluster`, etc.) as they won't change. I've hardcoded dummy values where we needed the outputs of these resources (e.g. `castai_aks_cluster.my_castai_cluster.id`)
- I've changed every `helm_release` to `helm_template`. Had to do minor trivial changes to make this work (e.g. remove `cleanup_on_fail` attributes). Also changed all `count`s to `1` so we generate everything.
```sh
gsed -i '
/ignore_changes/d;
/cleanup_on_fail/d;
s/count = .*$/count = 1/;
s/resource "helm_release"/data "helm_template"/;
s/helm_release\./data.helm_template./g;
s/castai_aks_cluster.castai_cluster.cluster_token/"castai.apiKey"/g;
s/castai_aks_cluster.castai_cluster.id/"castai.clusterID"/g;
' main.tf
```
- I've added a Terraform output for every `helm_template`:
```terraform
output "castai_agent" {  
  value = data.helm_template.castai_agent.manifests  
}  
  
output "castai_cluster_controller" {  
  value = data.helm_template.castai_cluster_controller[0].manifests  
}  
  
output "castai_cluster_controller_self_managed" {  
  value = data.helm_template.castai_cluster_controller_self_managed[0].manifests
}  
  
output "castai_evictor" {  
  value = data.helm_template.castai_evictor[0].manifests  
}  
  
output "castai_evictor_self_managed" {  
  value = data.helm_template.castai_evictor_self_managed[0].manifests  
}  
  
output "castai_evictor_ext" {  
  value = data.helm_template.castai_evictor_ext.manifests  
}  
  
output "castai_pod_pinner" {  
  value = data.helm_template.castai_pod_pinner[0].manifests  
}  
  
output "castai_pod_pinner_self_managed" {  
  value = data.helm_template.castai_pod_pinner_self_managed[0].manifests  
}  
  
output "castai_spot_handler" {  
  value = data.helm_template.castai_spot_handler.manifests  
}  
  
output "castai_kvisor" {  
  value = data.helm_template.castai_kvisor[0].manifests  
}    
  
output "castai_kvisor_self_managed" {  
  value = data.helm_template.castai_kvisor_self_managed[0].manifests  
}  
  
output "castai_workload_autoscaler" {  
  value = data.helm_template.castai_workload_autoscaler[0].manifests  
}  
  
output "castai_workload_autoscaler_self_managed" {  
  value = data.helm_template.castai_workload_autoscaler_self_managed[0].manifests  
}  
  
output "castai_pod_mutator" {  
  value = data.helm_template.castai_pod_mutator[0].manifests  
}  
  
output "castai_pod_mutator_self_managed" {  
  value = data.helm_template.castai_pod_mutator_self_managed[0].manifests  
}
```

With these changes in place, I've run `terraform apply && terraform output` to save the generated Helm manifests. Comparing these outputs before and after this change revealed no changes, meaning **the maniests will be exactly the same**.

Note that this is not a completely exhaustive test as it doesn't verify all potential combination of all variables, but it proves that it will work with the defaults.

I've also tested this module version with the `castai` provider's `aks_cluster` [example](https://github.com/castai/terraform-provider-castai/tree/master/examples/aks/aks_cluster).