### PR TITLE
feat: propagate `components_sets` to every component

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -598,6 +598,10 @@ resource "helm_release" "castai_evictor_ext" {
   version = var.evictor_ext_version
   values  = var.evictor_ext_values
 
+  set = concat(
+    local.set_components_sets,
+  )
+
   depends_on = [helm_release.castai_evictor]
 }
 
@@ -740,7 +744,7 @@ resource "helm_release" "castai_kvisor" {
     [for k, v in var.kvisor_controller_extra_args : {
       name  = "controller.extraArgs.${k}"
       value = v
-    }]
+    }],
   )
 
   set_sensitive = local.set_sensitive_apikey
@@ -774,7 +778,7 @@ resource "helm_release" "castai_kvisor_self_managed" {
     [for k, v in var.kvisor_controller_extra_args : {
       name  = "controller.extraArgs.${k}"
       value = v
-    }]
+    }],
   )
 
   set_sensitive = local.set_sensitive_apikey

--- a/variables.tf
+++ b/variables.tf
@@ -103,7 +103,7 @@ variable "castai_components_labels" {
 
 variable "castai_components_sets" {
   type        = map(string)
-  description = "Optional additional 'set' configurations for helm resources."
+  description = "Optional additional 'set' configurations for every CAST AI Helm release."
   default     = {}
 }
 


### PR DESCRIPTION
Some were missing it, even though it's supposed to be on every component. Also adjusting some of the formatting (missing commas) to align with `helm_releases` in the other clouds to help in diffing.