### PR TITLE
fix: allow WOOP Dynamic threshold and Semi-automatic limits

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,9 +229,11 @@ resource "castai_workload_scaling_policy" "this" {
   excluded_containers = try(each.value.excluded_containers, null)
 
   cpu {
-    function                 = try(each.value.cpu.function, "QUANTILE")
-    overhead                 = try(each.value.cpu.overhead, 0)
-    apply_threshold          = try(each.value.cpu.apply_threshold, 0.1)
+    function = try(each.value.cpu.function, "QUANTILE")
+    overhead = try(each.value.cpu.overhead, 0)
+    # Deprecated apply_threshold conflicts with apply_threshold_strategy on older providers;
+    # omit it when strategy is set so Dynamic/adaptive strategies can be configured.
+    apply_threshold          = try(each.value.cpu.apply_threshold_strategy, null) != null ? null : try(each.value.cpu.apply_threshold, 0.1)
     args                     = try(each.value.cpu.args, ["0.8"])
     look_back_period_seconds = try(each.value.cpu.look_back_period_seconds, null)
     min                      = try(each.value.cpu.min, null)
@@ -252,16 +254,20 @@ resource "castai_workload_scaling_policy" "this" {
     dynamic "limit" {
       for_each = try([each.value.cpu.limit], [])
       content {
-        type       = try(limit.value.type, null)
-        multiplier = try(limit.value.multiplier, null)
+        type                   = try(limit.value.type, null)
+        multiplier             = try(limit.value.multiplier, null)
+        only_if_original_exist = try(limit.value.only_if_original_exist, null)
+        only_if_original_lower = try(limit.value.only_if_original_lower, null)
       }
     }
   }
 
   memory {
-    function                 = try(each.value.memory.function, "MAX")
-    overhead                 = try(each.value.memory.overhead, 0.1)
-    apply_threshold          = try(each.value.memory.apply_threshold, 0.1)
+    function = try(each.value.memory.function, "MAX")
+    overhead = try(each.value.memory.overhead, 0.1)
+    # Deprecated apply_threshold conflicts with apply_threshold_strategy on older providers;
+    # omit it when strategy is set so Dynamic/adaptive strategies can be configured.
+    apply_threshold          = try(each.value.memory.apply_threshold_strategy, null) != null ? null : try(each.value.memory.apply_threshold, 0.1)
     args                     = try(each.value.memory.args, null)
     look_back_period_seconds = try(each.value.memory.look_back_period_seconds, null)
     min                      = try(each.value.memory.min, null)
@@ -282,8 +288,10 @@ resource "castai_workload_scaling_policy" "this" {
     dynamic "limit" {
       for_each = try([each.value.memory.limit], [])
       content {
-        type       = try(limit.value.type, null)
-        multiplier = try(limit.value.multiplier, null)
+        type                   = try(limit.value.type, null)
+        multiplier             = try(limit.value.multiplier, null)
+        only_if_original_exist = try(limit.value.only_if_original_exist, null)
+        only_if_original_lower = try(limit.value.only_if_original_lower, null)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Omit deprecated `apply_threshold` when `apply_threshold_strategy` is set so Dynamic / adaptive change sensitivity can be configured without a provider schema conflict.
- Forward `only_if_original_exist` and `only_if_original_lower` on CPU/memory `limit` blocks so Semi-automatic / Automatic limit modes work via the module.

Companion changes:
- Provider: https://github.com/castai/terraform-provider-castai/pull/763
- EKS module: https://github.com/castai/terraform-castai-eks-cluster/pull/179
- GKE module: https://github.com/castai/terraform-castai-gke-cluster/pull/147

## Test plan
- [ ] Validate policy with `apply_threshold_strategy = { type = "DEFAULT_ADAPTIVE" }` (no conflict)
- [ ] Apply limit with `only_if_original_*` flags and confirm Semi-automatic/Automatic in console
- [ ] Default path (no strategy) still uses Percentage 0.1 via `apply_threshold`