### PR TITLE
chore: don't allow azurerm 5.0.0 yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0, < 5.0 |
 | <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.26.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
@@ -474,8 +474,8 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 3 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.7.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 3.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.7.0, < 5.0 |
 | <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.26.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.7.0"
+      version = ">= 3.7.0, < 5.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3"
+      version = "~> 3.0"
     }
     castai = {
       source  = "castai/castai"


### PR DESCRIPTION
With the release of azurerm 5.0.0 (https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v5.0.0) we'll need to adapt this module to some of the breaking changes. While we work those out, let's release a version that's marked as requiring <5.0 so it won't break existing workflows.

Changes needed to work with 5.0.0 coming in a follow-up.