### PR TITLE
chore!: upgrade to azurerm provider 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0, < 5.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 5.0.1 |
 | <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.26.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
@@ -474,8 +474,8 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 3.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.7.0, < 5.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 3.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 5.0.1 |
 | <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.26.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |

--- a/iam.tf
+++ b/iam.tf
@@ -140,11 +140,10 @@ resource "azurerm_user_assigned_identity" "this" {
 }
 
 resource "azurerm_federated_identity_credential" "this" {
-  count               = var.authentication_method == "workload_identity" ? 1 : 0
-  name                = local.federated_identity_name
-  resource_group_name = var.resource_group
-  audience            = ["api://AzureADTokenExchange"]
-  issuer              = "https://accounts.google.com"
-  parent_id           = azurerm_user_assigned_identity.this[0].id
-  subject             = data.castai_impersonation_service_account.this[0].id
+  count                     = var.authentication_method == "workload_identity" ? 1 : 0
+  name                      = local.federated_identity_name
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = "https://accounts.google.com"
+  user_assigned_identity_id = azurerm_user_assigned_identity.this[0].id
+  subject                   = data.castai_impersonation_service_account.this[0].id
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.7.0, < 5.0"
+      version = ">= 5.0.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
     castai = {
       source  = "castai/castai"


### PR DESCRIPTION
Adapting this module to the 5.x release of the `azurerm` provider, following the upgrade guide: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/5.0-upgrade-guide

The changes are minor, but backwards incompatible as they need to reference fields (`azurerm_federated_identity_credential.user_assigned_identity_id`) that did not exist in the 4.x versions of the provider. This means this is a **breaking change**, will need to be released as a new major version and upcoming versions will only work with `azurerm` 5+.

## Proof of Work

I've successfully onboarded an AKS cluster with this change in place.