### PR TITLE
feat: add hpa_converters to workload scaling policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ module "castai-aks-cluster" {
       }
 
       excluded_containers = ["container-1", "container-2"]
+
+      # Convert existing HPA utilization (%) targets to AverageValue using the
+      # workload's original container requests. Ignored if HPA management is enabled.
+      hpa_converters = [
+        {
+          type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
+        }
+      ]
     }
   }
 
@@ -466,7 +474,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 5.0.1 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.26.0 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.55.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
 
@@ -476,7 +484,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 3.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 5.0.1 |
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.26.0 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.55.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
 

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 5.0.1 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.55.0 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.56.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
 
@@ -484,7 +484,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 3.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 5.0.1 |
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.55.0 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.56.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
 

--- a/main.tf
+++ b/main.tf
@@ -408,6 +408,13 @@ resource "castai_workload_scaling_policy" "this" {
       }
     }
   }
+
+  dynamic "hpa_converters" {
+    for_each = try(each.value.hpa_converters, [])
+    content {
+      type = hpa_converters.value.type
+    }
+  }
 }
 
 resource "castai_workload_custom_metrics_data_source" "this" {

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 8.26.0"
+      version = ">= 8.55.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 8.55.0"
+      version = ">= 8.56.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Propagates the `hpa_converters` block added in castai/terraform-provider-castai#774 to the cluster module.

When VPA is the sole optimization, this converts existing HPA utilization (%) targets to `AverageValue` using the workload's original container requests. If HPA management is enabled, it takes precedence over this setting.

### Changes
- `main.tf`: pass-through `dynamic "hpa_converters"` block on `castai_workload_scaling_policy`
- `README.md`: usage example + regenerated terraform-docs section
- `versions.tf`: bump castai provider to `>= 8.55.0`

### Usage
```hcl
workload_scaling_policies = {
  default = {
    hpa_converters = [
      {
        type = "AVERAGE_VALUE_FROM_ORIGINAL_REQUESTS"
      }
    ]
  }
}
```