### PR TITLE
feat: expose workload scaling policy startup two_phase_recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ module "castai-aks-cluster" {
 
       startup = {
         period_seconds = 300
+        two_phase_recommendations = {
+          enabled = true
+          requests_on_startup = {
+            cpu_cores  = 0.5
+            memory_gib = 1.5
+          }
+        }
       }
 
       predictive_scaling = {
@@ -474,7 +481,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 5.0.1 |
-| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.56.0 |
+| <a name="requirement_castai"></a> [castai](#requirement\_castai) | >= 8.57.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
 
@@ -484,7 +491,7 @@ Usage examples are located in [terraform provider repo](https://github.com/casta
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 3.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 5.0.1 |
-| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.56.0 |
+| <a name="provider_castai"></a> [castai](#provider\_castai) | >= 8.57.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.1.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
 

--- a/main.tf
+++ b/main.tf
@@ -340,6 +340,21 @@ resource "castai_workload_scaling_policy" "this" {
     for_each = try([each.value.startup], [])
     content {
       period_seconds = try(startup.value.period_seconds, null)
+
+      dynamic "two_phase_recommendations" {
+        for_each = try([startup.value.two_phase_recommendations], [])
+        content {
+          enabled = try(two_phase_recommendations.value.enabled, null)
+
+          dynamic "requests_on_startup" {
+            for_each = try([two_phase_recommendations.value.requests_on_startup], [])
+            content {
+              cpu_cores  = try(requests_on_startup.value.cpu_cores, null)
+              memory_gib = try(requests_on_startup.value.memory_gib, null)
+            }
+          }
+        }
+      }
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 8.56.0"
+      version = ">= 8.57.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
 Mirrors the new `two_phase_recommendations` block added to `castai_workload_scaling_policy.startup` in provider release 8.56.0.

Changes:
- Pass through `startup.two_phase_recommendations` and its nested `requests_on_startup` block.
- Bump CAST AI provider constraint to `>= 8.57.0`.
- Update README usage example.